### PR TITLE
Fixed a bug in rail route trimming

### DIFF
--- a/src/util/domain.js
+++ b/src/util/domain.js
@@ -54,7 +54,7 @@ function isTrunkRoute(routeId) {
  */
 function trimRouteId(routeId) {
     if (isRailRoute(routeId) && isNumberVariant(routeId)) {
-        return routeId.substring(1, 5).replace(RAIL_ROUTE_ID_REGEXP, "");
+        return routeId.substring(0, 5).replace(RAIL_ROUTE_ID_REGEXP, "");
     } else if (isRailRoute(routeId)) {
         return routeId.replace(RAIL_ROUTE_ID_REGEXP, "");
     } else if (isSubwayRoute(routeId) && isNumberVariant(routeId)) {


### PR DESCRIPTION
The routeId '3002U6' would be incorrectly shown as '002U'.

This is included in the unit test suite for digitransit-ui, see: https://github.com/HSLdevcom/digitransit-ui/blob/DT-2284/test/unit/domain.test.js#L17