### PR TITLE
Use dev server for generating the poster

### DIFF
--- a/src/util/map.js
+++ b/src/util/map.js
@@ -1,4 +1,4 @@
-const API_URL = 'http://kartat.hsl.fi';
+const API_URL = 'https://dev-kartat.hsldev.com';
 
 const scale = 5;
 


### PR DESCRIPTION
Temporarily use the dev server for generating the poster map. This should probably not be pulled into the prod development.