### PR TITLE
Server url from env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN groupadd -r pptruser && useradd -r -g pptruser -G audio,video pptruser \
     && chown -R pptruser:pptruser /home/pptruser
 
 ENV WORK /opt/publisher
+ENV API_URL "https://dev-kartat.hsldev.com"
 
 RUN mkdir -p ${WORK}
 WORKDIR ${WORK}

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN groupadd -r pptruser && useradd -r -g pptruser -G audio,video pptruser \
     && chown -R pptruser:pptruser /home/pptruser
 
 ENV WORK /opt/publisher
-ENV API_URL "https://dev-kartat.hsldev.com"
+ENV API_URL http://kartat.hsl.fi
 
 RUN mkdir -p ${WORK}
 WORKDIR ${WORK}

--- a/src/util/map.js
+++ b/src/util/map.js
@@ -1,6 +1,6 @@
-const API_URL = 'https://dev-kartat.hsldev.com';
-
-console.log(process.env.API_URL || 'No api url env');
+// API_URL is provided by Webpack.
+// eslint-disable-next-line no-undef
+const serverUrl = API_URL || 'http://kartat.hsl.fi';
 
 const scale = 5;
 
@@ -17,7 +17,7 @@ export function fetchMap(mapOptions, mapStyle) {
     body: JSON.stringify({ options: { ...mapOptions, scale }, style: mapStyle }),
   };
 
-  return fetch(`${API_URL}/generateImage`, options)
+  return fetch(`${serverUrl}/generateImage`, options)
     .then(response => response.blob())
     .then(
       blob =>

--- a/src/util/map.js
+++ b/src/util/map.js
@@ -1,5 +1,7 @@
 const API_URL = 'https://dev-kartat.hsldev.com';
 
+console.log(process.env.API_URL || 'No api url env');
+
 const scale = 5;
 
 /**

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -11,7 +11,7 @@ module.exports = {
       title: 'Stop poster',
     }),
     new webpack.DefinePlugin({
-      'process.env.API_URL': JSON.stringify(process.env.API_URL),
+      API_URL: JSON.stringify(process.env.API_URL || ''),
     }),
   ],
   resolve: {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
+const webpack = require('webpack');
 
 module.exports = {
   entry: ['babel-polyfill', './src/index.js'],
@@ -8,6 +9,9 @@ module.exports = {
     new CleanWebpackPlugin(['dist']),
     new HtmlWebpackPlugin({
       title: 'Stop poster',
+    }),
+    new webpack.DefinePlugin({
+      'process.env.API_URL': JSON.stringify(process.env.API_URL),
     }),
   ],
   resolve: {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -11,7 +11,8 @@ module.exports = {
       title: 'Stop poster',
     }),
     new webpack.DefinePlugin({
-      API_URL: JSON.stringify(process.env.API_URL || ''),
+      // stringify may do something weird with empty strings, ensure a clean empty string if API_URL is undefined.
+      API_URL: process.env.API_URL ? JSON.stringify(process.env.API_URL) : '',
     }),
   ],
   resolve: {

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -4,7 +4,7 @@ const webpackCommon = require('./webpack.common');
 
 const PORT = process.env.PORT || 5000;
 
-module.exports = merge(webpackCommon, {
+module.exports = merge.smart(webpackCommon, {
   mode: 'development',
   devtool: 'cheap-module-eval-source-map',
   serve: {
@@ -13,4 +13,9 @@ module.exports = merge(webpackCommon, {
       hmr: true,
     },
   },
+  plugins: [
+    new webpack.DefinePlugin({
+      API_URL: 'https://dev-kartat.hsldev.com',
+    }),
+  ],
 });


### PR DESCRIPTION
Reads the API url for the map generation service from env. The production endpoint is set as default, but now that we're testing a new update to the generator server it is convenient to be able to set the url from the docker-compose file. This PR enables that.