### PR TITLE
Larger font size for printed timetables.

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -110,7 +110,7 @@ class App extends Component {
           this.root = ref;
         }}>
         <ApolloProvider client={client}>
-          <ComponentToRender {...props} template={template} />
+          <ComponentToRender {...props} standalone template={template} />
         </ApolloProvider>
       </div>
     );

--- a/src/components/timetable/tableHeader.css
+++ b/src/components/timetable/tableHeader.css
@@ -1,5 +1,5 @@
 .root {
-  margin: 15px 0;
+  margin: 0.938em 0;
   font-family: GothamRounded-Book;
   color: var(--timetable-text-color);
   page-break-after: avoid;
@@ -14,18 +14,18 @@
 }
 
 .title {
-  padding: 5px 10px;
-  font-size: 18px;
+  padding: 0.313em 0.45em;
+  font-size: 1.125em;
 }
 
 .subtitle {
   display: flex;
-  padding: 0 10px;
-  font-size: 12px;
-  line-height: 13px;
+  padding: 0 0.625em 0 0.65em;
+  font-size: 0.75em;
+  line-height: 1;
   letter-spacing: -0.025em;
 }
 
 .subtitle > *:first-child {
-  width: 50px;
+  min-width: 4.2em;
 }

--- a/src/components/timetable/tableRows.css
+++ b/src/components/timetable/tableRows.css
@@ -13,22 +13,22 @@
 
 .item {
   display: flex;
-  min-width: 60px;
-  padding: 4px 0;
+  min-width: 3.75em;
+  padding: 0.25em 0;
   font-family: GothamXNarrow-Book;
-  font-size: 12px;
+  font-size: 0.75em;
   letter-spacing: -0.025em;
-  line-height: 8px;
-  margin-right: 4px;
+  line-height: 1;
+  margin-right: 0.25em;
 }
 
 .minutes {
-  min-width: 12px;
+  min-width: 0.75em;
   font-family: GothamXNarrow-Medium;
 }
 
 .hours {
   composes: item;
-  padding-left: 15px;
+  padding-left: 0.938em;
   font-family: GothamXNarrow-Medium;
 }

--- a/src/components/timetable/timetable.css
+++ b/src/components/timetable/timetable.css
@@ -7,6 +7,11 @@
   color: var(--hsl-blue);
   background: var(--light-background);
   --timetable-accent-color: white;
+  font-size: 16px;
+}
+
+.root.standalone {
+  font-size: 22px;
 }
 
 .root > div {
@@ -30,8 +35,8 @@
 }
 
 .componentName {
-  padding: 0px 10px;
-  font-size: 30px;
+  padding: 0 0.205em;
+  font-size: 1.875em;
 }
 
 .title {
@@ -43,9 +48,9 @@
 }
 
 .footnote {
-  padding: 2px 10px;
+  padding: 0.125em 0.625em;
   font-family: GothamXNarrow-Book;
-  font-size: 13px;
+  font-size: 0.813em;
 }
 
 .validity {
@@ -53,8 +58,8 @@
   top: calc(var(--border-radius) - 15px);
   right: var(--border-radius);
   font-family: GothamRounded-Book;
-  font-size: 12px;
-  line-height: 16px;
+  font-size: 0.75em;
+  line-height: 1.1;
   letter-spacing: -0.025em;
   text-align: right;
 }

--- a/src/components/timetable/timetable.js
+++ b/src/components/timetable/timetable.js
@@ -13,6 +13,7 @@ const Timetable = props => (
     className={classNames(styles.root, {
       [styles.summer]: props.isSummerTimetable,
       [styles.printable]: props.printableAsA4,
+      [styles.standalone]: props.standalone,
       [styles.greyscale]: props.greyscale,
     })}>
     {props.showStopInformation && (
@@ -85,6 +86,7 @@ Timetable.defaultProps = {
   showNotes: true,
   showComponentName: true,
   printableAsA4: false,
+  standalone: false,
   greyscale: false,
 };
 
@@ -104,6 +106,7 @@ Timetable.propTypes = {
   stopShortId: PropTypes.string.isRequired,
   stopNameFi: PropTypes.string.isRequired,
   stopNameSe: PropTypes.string.isRequired,
+  standalone: PropTypes.bool,
   greyscale: PropTypes.bool,
 };
 

--- a/src/components/timetable/timetableContainer.js
+++ b/src/components/timetable/timetableContainer.js
@@ -238,6 +238,7 @@ const propsMapper = mapProps(props => {
     stopShortId: props.data.stop.shortId,
     printableAsA4: props.printTimetablesAsA4,
     greyscale: props.printTimetablesAsGreyscale,
+    standalone: props.standalone,
   };
 });
 
@@ -270,6 +271,7 @@ TimetableContainer.propTypes = {
   showNotes: PropTypes.bool,
   segments: PropTypes.arrayOf(PropTypes.oneOf(['weekdays', 'saturdays', 'sundays'])),
   showComponentName: PropTypes.bool,
+  standalone: PropTypes.bool,
   printTimetablesAsA4: PropTypes.bool,
   printTimetablesAsGreyscale: PropTypes.bool,
 };


### PR DESCRIPTION
Same goal as PR #177 but implemented with em units to make all elements resize in uniform based on one font-size value.

em values are calculated from a base of 16, which is what the timetable root element will have when not in standalone mode.