### PR TITLE
Fix ide renaming mess.

### DIFF
--- a/src/components/routeDiagram/routeDiagram.css
+++ b/src/components/routeDiagram/routeDiagram.css
@@ -16,17 +16,17 @@
   --line-border: var(--line-width) solid var(--line-color);
 }
 
-.headerElement {
+.componentName {
   padding: 0px 0px 20px;
   font-size: 30px;
   color: var(--hsl-blue);
 }
 
-.headerElement > .title {
+.componentName > .title {
   font-family: GothamRounded-Medium;
 }
 
-.headerElement > .subtitle {
+.componentName > .subtitle {
   font-family: GothamRounded-Book;
 }
 

--- a/src/components/tramDiagram/tramDiagram.css
+++ b/src/components/tramDiagram/tramDiagram.css
@@ -5,18 +5,18 @@
   position: relative;
 }
 
-.headerElement {
+.componentName {
   padding: 42px;
   font-size: 30px;
   color: var(--hsl-blue);
   position: absolute;
 }
 
-.headerElement > .title {
+.componentName > .title {
   font-family: GothamRounded-Medium;
 }
 
-.headerElement > .subtitle {
+.componentName > .subtitle {
   font-family: GothamRounded-Book;
 }
 


### PR DESCRIPTION
My IDE messed up the refactoring when I renamed a CSS class in the standalone timetable PR, and renamed everywhere it found that name. Here is the fix that renames unrelated classes back to what they were.