### PR TITLE
Remove tram diagram CSS adjustments.

### DIFF
--- a/src/components/tramDiagram/tramDiagram.css
+++ b/src/components/tramDiagram/tramDiagram.css
@@ -22,8 +22,9 @@
 
 .diagram {
   display: block;
-  margin-top: -80px; /* Remove extra padding from the top to make the diagram more compact */
-  margin-left: -20px; /* Align the edge of the legend box with the heading */
-  margin-right: -20px; /* Reduce some of the resulting height increase */
-  margin-bottom: -10px; /* Remove padding from the bottom to balance the layout */
+}
+
+.diagram svg {
+  display: block;
+  margin: 0;
 }


### PR DESCRIPTION
Update the tram diagram with a future-proof version that does not require adjustments.