### PR TITLE
timetable page break removed

### DIFF
--- a/src/components/timetable/timetable.css
+++ b/src/components/timetable/timetable.css
@@ -14,10 +14,6 @@
   font-size: 22px;
 }
 
-.root > div {
-  page-break-inside: avoid;
-}
-
 .root.summer {
   background: white;
   --timetable-accent-color: var(--light-background);


### PR DESCRIPTION
Small css change to remove page changes in the printable timetable sheets