### PR TITLE
DO NOT MERGE: Bruteforce finding suitable route diagram

### DIFF
--- a/src/components/stopPoster/stopPoster.js
+++ b/src/components/stopPoster/stopPoster.js
@@ -250,7 +250,6 @@ class StopPoster extends Component {
         return;
       }
 
-      this.onError('Failed to remove layout overflow');
       return;
     }
 
@@ -265,6 +264,10 @@ class StopPoster extends Component {
     if (!this.state.shouldRenderMap && !this.state.triedRenderingMap) {
       this.setState({ shouldRenderMap: true });
       return;
+    }
+
+    if (this.hasOverflow()) {
+      this.onError('Failed to remove layout overflow');
     }
 
     window.setTimeout(() => {

--- a/src/components/stopPoster/stopPoster.js
+++ b/src/components/stopPoster/stopPoster.js
@@ -44,6 +44,7 @@ class StopPoster extends Component {
       shouldRenderMap: false,
       triedRenderingMap: false,
       hasColumnTimetable: true,
+      removedAds: [],
     };
   }
 
@@ -106,6 +107,16 @@ class StopPoster extends Component {
     return this.content.scrollHeight > this.content.clientHeight;
   }
 
+  removeAdFromTemplate(ads) {
+    const { template, removedAds } = this.state;
+    removedAds.push(ads.slots.pop());
+    template.areas.find(t => t.key === 'ads').slots = ads.slots;
+    this.setState({
+      removedAds,
+      template,
+    });
+  }
+
   updateLayout() {
     if (!this.props.hasRoutes) {
       this.onError('No valid routes for stop');
@@ -128,26 +139,36 @@ class StopPoster extends Component {
         return;
       }
 
-
       if (this.state.hasDiagram) {
         this.setState({ hasDiagram: false });
         return;
       }
 
       if (this.state.template) {
-        const ads = get(this.state.template, 'areas', []).find(t => t.key === 'ads')
+        const ads = get(this.state.template, 'areas', []).find(t => t.key === 'ads');
         if (ads.slots.length > 0) {
-          ads.slots.pop();
-          const template = this.state.template;
-          template.areas.find(t => t.key === 'ads').slots = ads.slots;
-          this.setState({ template });
+          this.removeAdFromTemplate(ads);
           return;
         }
       }
 
       if (this.state.hasColumnTimetable) {
-        this.setState({ hasColumnTimetable: false });
+        const { template, removedAds } = this.state;
+        template.areas.find(t => t.key === 'ads').slots = removedAds;
+        this.setState({
+          hasColumnTimetable: false,
+          removedAds: [],
+          template,
+        });
         return;
+      }
+
+      if (this.state.template) {
+        const ads = get(this.state.template, 'areas', []).find(t => t.key === 'ads');
+        if (ads.slots.length > 0) {
+          this.removeAdFromTemplate(ads);
+          return;
+        }
       }
 
       if (this.state.hasRoutes) {

--- a/src/components/stopPoster/stopPoster.js
+++ b/src/components/stopPoster/stopPoster.js
@@ -155,18 +155,21 @@ class StopPoster extends Component {
     if (this.state.adsPhase) {
       const { template, removedAds } = this.state;
       const ads = get(template, 'areas', []).find(t => t.key === 'ads');
+
+      if (
+        !removedAds ||
+        removedAds.length === 0 ||
+        (this.hasOverflow() && ads.slots.length === 0)
+      ) {
+        this.setState({ adsPhase: false });
+      }
+
       if (this.hasOverflow()) {
         ads.slots.pop();
       } else {
         ads.slots.push(removedAds.pop());
       }
 
-      if (!removedAds || removedAds.length === 0) {
-        this.setState({ adsPhase: false });
-      }
-      if (this.hasOverflow() && ads.slots.length === 0) {
-        this.setState({ adsPhase: false });
-      }
       template.areas.find(t => t.key === 'ads').slots = ads.slots;
       this.setState({
         template,
@@ -250,6 +253,7 @@ class StopPoster extends Component {
         return;
       }
 
+      this.onError('Failed to remove layout overflow');
       return;
     }
 
@@ -264,10 +268,6 @@ class StopPoster extends Component {
     if (!this.state.shouldRenderMap && !this.state.triedRenderingMap) {
       this.setState({ shouldRenderMap: true });
       return;
-    }
-
-    if (this.hasOverflow()) {
-      this.onError('Failed to remove layout overflow');
     }
 
     window.setTimeout(() => {

--- a/src/components/stopPoster/stopPoster.js
+++ b/src/components/stopPoster/stopPoster.js
@@ -25,11 +25,6 @@ import CustomMap from '../map/customMap';
 const ROUTE_DIAGRAM_MAX_HEIGHT = 25;
 const ROUTE_DIAGRAM_MIN_HEIGHT = 10;
 
-const diagramConfig = {
-  heightValues: Array.from(Array(ROUTE_DIAGRAM_MAX_HEIGHT - ROUTE_DIAGRAM_MIN_HEIGHT).keys()),
-  middleHeightValue: null,
-};
-
 const trunkStopStyle = {
   '--background': colorsByMode.TRUNK,
   '--light-background': '#FFE0D1',
@@ -55,6 +50,10 @@ class StopPoster extends Component {
       hasColumnTimetable: true,
       removedAds: null,
       adsPhase: false,
+      diagramConfig: {
+        heightValues: Array.from(Array(ROUTE_DIAGRAM_MAX_HEIGHT - ROUTE_DIAGRAM_MIN_HEIGHT).keys()),
+        middleHeightValue: null,
+      },
     };
   }
 
@@ -187,18 +186,22 @@ class StopPoster extends Component {
         if (this.state.routeDiagramStopCount >= ROUTE_DIAGRAM_MIN_HEIGHT) {
           // TODO: This is kind of dirty fix. Binarysearching first acceptable value
           // from the possible heightValues for diagram.
+
           let { routeDiagramStopCount } = this.state;
+          const { diagramConfig } = this.state;
           const len = diagramConfig.heightValues.length;
           diagramConfig.heightValues = diagramConfig.heightValues.slice(Math.floor(len / 2), len);
-          diagramConfig.middleHeightValue = diagramConfig.heightValues[Math.floor(len / 2)];
+          diagramConfig.middleHeightValue =
+            diagramConfig.heightValues[Math.floor(diagramConfig.heightValues.length / 2)];
           routeDiagramStopCount = ROUTE_DIAGRAM_MAX_HEIGHT - diagramConfig.middleHeightValue;
 
-          if (len === 1) {
+          if (diagramConfig.heightValues.length === 1 || !routeDiagramStopCount) {
             this.setState({ hasDiagram: false });
           }
 
           this.setState({
             routeDiagramStopCount,
+            diagramConfig,
           });
         } else {
           this.setState({ hasDiagram: false });
@@ -219,16 +222,9 @@ class StopPoster extends Component {
       }
 
       if (this.state.shouldRenderMap) {
-        // If map doesnt fit in we try adding routetree again.
-        diagramConfig.heightValues = Array.from(
-          Array(ROUTE_DIAGRAM_MAX_HEIGHT - ROUTE_DIAGRAM_MIN_HEIGHT).keys(),
-        );
-        diagramConfig.middleHeightValue = null;
         this.setState({
           shouldRenderMap: false,
           triedRenderingMap: true,
-          hasDiagram: true,
-          routeDiagramStopCount: ROUTE_DIAGRAM_MAX_HEIGHT,
         });
         return;
       }

--- a/src/components/stopPoster/stopPoster.js
+++ b/src/components/stopPoster/stopPoster.js
@@ -23,7 +23,7 @@ import styles from './stopPoster.css';
 import CustomMap from '../map/customMap';
 
 const ROUTE_DIAGRAM_MAX_HEIGHT = 25;
-const ROUTE_DIAGRAM_MIN_HEIGHT = 6;
+const ROUTE_DIAGRAM_MIN_HEIGHT = 8;
 
 const trunkStopStyle = {
   '--background': colorsByMode.TRUNK,
@@ -31,8 +31,6 @@ const trunkStopStyle = {
 };
 
 class StopPoster extends Component {
-  isDiagramSearchOngoing = false;
-
   constructor(props) {
     super(props);
 
@@ -134,7 +132,7 @@ class StopPoster extends Component {
       return;
     }
 
-    if (this.hasOverflow() || this.isDiagramSearchOngoing) {
+    if (this.hasOverflow()) {
       if (!this.state.hasRoutesOnTop) {
         this.setState({ hasRoutesOnTop: true });
         return;
@@ -154,35 +152,17 @@ class StopPoster extends Component {
       }
 
       if (this.state.hasDiagram) {
-        if (this.state.routeDiagramStopCount > ROUTE_DIAGRAM_MIN_HEIGHT && this.hasOverflow()) {
+        if (this.state.routeDiagramStopCount >= ROUTE_DIAGRAM_MIN_HEIGHT) {
           // TODO: This is a dirty fix that bruteforce finds a suitable routeDiagram,
           // should be made better since it practically breaks posters where we have a map
-          // eslint-disable-next-line
-          this.setState({ routeDiagramStopCount: this.state.routeDiagramStopCount - 1 });
-          this.isDiagramSearchOngoing = true;
-        } else {
-          if (this.hasOverflow()) {
-            this.setState({
-              hasDiagram: false,
-            });
-          }
-          this.isDiagramSearchOngoing = false;
-          const { template, removedAds } = this.state;
-          template.areas.find(t => t.key === 'ads').slots = removedAds;
           this.setState({
-            removedAds: [],
-            template,
+            // eslint-disable-next-line
+            routeDiagramStopCount: this.state.routeDiagramStopCount - 1,
           });
+        } else {
+          this.setState({ hasDiagram: false });
         }
         return;
-      }
-
-      if (this.state.template) {
-        const ads = get(this.state.template, 'areas', []).find(t => t.key === 'ads');
-        if (ads.slots.length > 0) {
-          this.removeAdFromTemplate(ads);
-          return;
-        }
       }
 
       if (this.state.hasColumnTimetable) {

--- a/src/components/stopPoster/stopPoster.js
+++ b/src/components/stopPoster/stopPoster.js
@@ -23,7 +23,7 @@ import styles from './stopPoster.css';
 import CustomMap from '../map/customMap';
 
 const ROUTE_DIAGRAM_MAX_HEIGHT = 25;
-const ROUTE_DIAGRAM_MIN_HEIGHT = 8;
+const ROUTE_DIAGRAM_MIN_HEIGHT = 10;
 
 const trunkStopStyle = {
   '--background': colorsByMode.TRUNK,

--- a/src/components/stopPoster/stopPoster.js
+++ b/src/components/stopPoster/stopPoster.js
@@ -172,10 +172,13 @@ class StopPoster extends Component {
 
       template.areas.find(t => t.key === 'ads').slots = ads.slots;
 
-      this.setState({
-        template,
-        removedAds,
-      });
+      window.setTimeout(() => {
+        this.setState({
+          template,
+          removedAds,
+        });
+      }, 1000);
+
       return;
     }
 
@@ -193,7 +196,6 @@ class StopPoster extends Component {
       if (this.state.hasDiagram) {
         // TODO: This is kind of dirty fix. Binarysearch to get acceptable
         // height for routetree.
-
         const { diagramOptions } = this.state;
         diagramOptions.binarySearching = true;
         diagramOptions.middleHeightValue =

--- a/src/components/stopPoster/stopPoster.js
+++ b/src/components/stopPoster/stopPoster.js
@@ -258,18 +258,16 @@ class StopPoster extends Component {
       return;
     }
 
-    // If there is no layout overflow and the map is not rendered, try rendering the map again.
-    if (!this.state.shouldRenderMap && !this.state.triedRenderingMap) {
-      this.setState({ shouldRenderMap: true });
+    if (this.state.template && this.state.removedAds.length > 0) {
+      this.setState({
+        adsPhase: true,
+      });
       return;
     }
 
-    if (this.state.template && this.state.removedAds.length > 0) {
-      // We don't want to render map multiple times when doing the ads.
-      this.setState({
-        adsPhase: true,
-        shouldRenderMap: false,
-      });
+    // If there is no layout overflow and the map is not rendered, try rendering the map again.
+    if (!this.state.shouldRenderMap && !this.state.triedRenderingMap) {
+      this.setState({ shouldRenderMap: true });
       return;
     }
 

--- a/src/components/stopPoster/stopPoster.js
+++ b/src/components/stopPoster/stopPoster.js
@@ -407,7 +407,7 @@ class StopPoster extends Component {
                   )}
                 </Measure>
               </div>
-              <Spacer width="100%" height={62} />
+              <Spacer width="100%" height={50} />
             </div>
             <Footer
               onError={this.onError}

--- a/src/components/stopPoster/stopPoster.js
+++ b/src/components/stopPoster/stopPoster.js
@@ -171,6 +171,7 @@ class StopPoster extends Component {
       }
 
       template.areas.find(t => t.key === 'ads').slots = ads.slots;
+
       this.setState({
         template,
         removedAds,
@@ -257,16 +258,18 @@ class StopPoster extends Component {
       return;
     }
 
-    if (this.state.template && this.state.removedAds.length > 0) {
-      this.setState({
-        adsPhase: true,
-      });
-      return;
-    }
-
     // If there is no layout overflow and the map is not rendered, try rendering the map again.
     if (!this.state.shouldRenderMap && !this.state.triedRenderingMap) {
       this.setState({ shouldRenderMap: true });
+      return;
+    }
+
+    if (this.state.template && this.state.removedAds.length > 0) {
+      // We don't want to render map multiple times when doing the ads.
+      this.setState({
+        adsPhase: true,
+        shouldRenderMap: false,
+      });
       return;
     }
 

--- a/src/components/stopPoster/stopPoster.js
+++ b/src/components/stopPoster/stopPoster.js
@@ -138,11 +138,6 @@ class StopPoster extends Component {
       return;
     }
 
-    if (this.hasOverflow() && this.state.triedRenderingMap && !this.state.adsPhase) {
-      this.onError('Unsolvable layout overflow.');
-      return;
-    }
-
     // Remove ads from template and try to add them later when there's no overflow.
     // i.e when this.state.adsPhase = true
     if (this.state.template && !this.state.removedAds) {
@@ -230,10 +225,7 @@ class StopPoster extends Component {
           }
         }
 
-        this.setState({
-          diagramOptions,
-        });
-
+        this.setState({ diagramOptions });
         return;
       }
 
@@ -261,6 +253,11 @@ class StopPoster extends Component {
       }
 
       this.onError('Failed to remove layout overflow');
+      return;
+    }
+
+    if (this.hasOverflow() && this.state.triedRenderingMap) {
+      this.onError('Unsolvable layout overflow.');
       return;
     }
 

--- a/src/components/stopPoster/stopPoster.js
+++ b/src/components/stopPoster/stopPoster.js
@@ -23,7 +23,7 @@ import styles from './stopPoster.css';
 import CustomMap from '../map/customMap';
 
 const ROUTE_DIAGRAM_MAX_HEIGHT = 25;
-const ROUTE_DIAGRAM_MIN_HEIGHT = 1;
+const ROUTE_DIAGRAM_MIN_HEIGHT = 6;
 
 const trunkStopStyle = {
   '--background': colorsByMode.TRUNK,

--- a/src/components/stopPoster/stopPoster.js
+++ b/src/components/stopPoster/stopPoster.js
@@ -166,22 +166,10 @@ class StopPoster extends Component {
       }
 
       if (this.state.hasColumnTimetable) {
-        const { template, removedAds } = this.state;
-        template.areas.find(t => t.key === 'ads').slots = removedAds;
         this.setState({
           hasColumnTimetable: false,
-          removedAds: [],
-          template,
         });
         return;
-      }
-
-      if (this.state.template) {
-        const ads = get(this.state.template, 'areas', []).find(t => t.key === 'ads');
-        if (ads.slots.length > 0) {
-          this.removeAdFromTemplate(ads);
-          return;
-        }
       }
 
       if (this.state.hasRoutes) {

--- a/src/util/routes.js
+++ b/src/util/routes.js
@@ -2,9 +2,6 @@ import get from 'lodash/get';
 import { itemsToTree, generalizeTree, sortBranches } from 'util/tree';
 
 const MAX_WIDTH = 6;
-const MAX_HEIGHT = 25;
-// The value to divide a pixel height by to reach the unit used for MAX_HEIGHT.
-const STOP_PX_HEIGHT = 35;
 
 function isEqual(stop, other) {
   if (stop.type !== other.type) return false;
@@ -95,18 +92,9 @@ function routesToTree(routes, { stopZone, shortId }, height = 'auto') {
 
   const root = itemsToTree(itemsListWithZoneBorders, { isEqual, merge });
 
-  // height is auto if the generated local map is used. Only if
-  // a static image is set will height be a px value, in which case maxHeight
-  // needs to be adjusted here to not cause overflow errors.
-  const maxHeight =
-    height !== 'auto'
-      ? // The diagram height is whatever is left over from the map.
-        Math.min(Math.floor(height / STOP_PX_HEIGHT), MAX_HEIGHT)
-      : MAX_HEIGHT;
-
   generalizeTree(root, {
+    height,
     width: MAX_WIDTH,
-    height: maxHeight,
     prune,
     truncate,
   });


### PR DESCRIPTION
RouteDiagram was missing from most of the posters in production. I assume this problem is due to the programs inability to calculate the correct height in which it should render the route diagram. This often led to the program generating a route diagram that was too big, and therefore removed due to overflow. This PR is a fast fix to get the route diagrams back in to production, and therefore this branch is now (9.5.2019) deployed into production.
This is however not a viable solution, since this "fix" only seems to work when there is a svg, and no lähikartta. This is not a problem for this batch, but is certainly something that needs to be fixed before merging to master.
