### PR TITLE
Improved errors with map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-HSL Map Publisher
-====================
+# HSL Map Publisher
 
 This project is the server-side component of the poster publisher (the UI can be found in [HSLdevcom/hsl-map-publisher-ui](https://github.com/HSLdevcom/hsl-map-publisher-ui)) that generates the stop posters that you see on public transport stops around the Helsinki area. It uses PostgreSQL as the database where the poster data and generation status is stored, React for rendering the posters, Puppeteer for generating PDF's of the poster app and Koa as the server to tie everything together.
 
@@ -44,6 +43,7 @@ Each component will add itself to the "render queue" when mounted, an operation 
 Server and REST API for printing components to PDF files and managing their metadata in a Postgres database.
 
 Start Postgres:
+
 ```
 docker run -p 0.0.0.0:5432:5432 --env POSTGRES_PASSWORD=postgres --name publisher-postgres postgres
 ```
@@ -78,23 +78,26 @@ npm start
 
 Now you can use the UI with the server, or open a poster separately in your browser. The poster app needs `component` and `props` query parameters, and the server will echo the currently rendering URL in its console. But if you just need to open the poster app, you can use this link that will show H0454, Snellmaninkatu:
 
-`http://localhost:5000/?component=StopPoster&props%5BstopId%5D=1010124&props%5Bdate%5D=2018-09-13&props%5BisSummerTimetable%5D=false&props%5BdateBegin%5D=&props%5BdateEnd%5D=&props%5BprintTimetablesAsA4%5D=false&props%5BprintTimetablesAsGreyscale%5D=false&template=mock_template`
+`http://localhost:5000/?component=StopPoster&props%5BstopId%5D=1140196&props%5Bdate%5D=2019-09-30&props%5BisSummerTimetable%5D=true&props%5BdateBegin%5D=&props%5BdateEnd%5D=&props%5BprintTimetablesAsA4%5D=false&props%5BprintTimetablesAsGreyscale%5D=false&template=mock_template`
 
 You will have to create a template using the Publisher UI. The poster app will download the template from the Publisher server.
 
 ### Running in Docker
 
 As before, make sure you are running a database for the publisher:
+
 ```bash
 docker run -p 0.0.0.0:5432:5432 --env POSTGRES_PASSWORD=postgres --name publisher-postgres postgres
 ```
 
 Build the Docker image with the following command:
+
 ```bash
 docker build -t hsldevcom/hsl-map-publisher .
 ```
 
 And run the Docker container with this command:
+
 ```bash
 docker run -d -p 4000:4000 --name publisher -v $(pwd)/output:/output -v $(pwd)/fonts:/fonts --link publisher-postgres -e "PG_CONNECTION_STRING=postgres://postgres:postgres@publisher-postgres:5432/postgres" --shm-size=1G hsl-map-publisher
 ```

--- a/src/util/map.js
+++ b/src/util/map.js
@@ -9,7 +9,7 @@ const scale = 5;
  */
 // eslint-disable-next-line import/prefer-default-export
 export async function fetchMap(mapOptions, mapStyle) {
-  const serverUrl = 'http://localhost:8000';
+  const serverUrl = process.env.GENERATE_API_URL || 'https://kartat.hsl.fi';
   window.serverLog(`Generating the map with ${serverUrl}`);
 
   const options = {

--- a/src/util/map.js
+++ b/src/util/map.js
@@ -20,9 +20,9 @@ export async function fetchMap(mapOptions, mapStyle) {
 
   const response = await fetch(`${serverUrl}/generateImage`, options);
   const blob = await response.blob();
-  if (response && response.status === 500) {
+  if (response && response.status >= 500) {
     renderQueue.remove(this, {
-      error: new Error(`Received status code 500 from generator-server`),
+      error: new Error(`Received status code ${response.status} from generator-server`),
     });
   }
   return new Promise(resolve => {

--- a/src/util/map.js
+++ b/src/util/map.js
@@ -1,3 +1,5 @@
+import renderQueue from 'util/renderQueue';
+
 const scale = 5;
 
 /**
@@ -7,7 +9,7 @@ const scale = 5;
  */
 // eslint-disable-next-line import/prefer-default-export
 export async function fetchMap(mapOptions, mapStyle) {
-  const serverUrl = process.env.GENERATE_API_URL || 'https://kartat.hsl.fi';
+  const serverUrl = 'http://localhost:8000';
   window.serverLog(`Generating the map with ${serverUrl}`);
 
   const options = {
@@ -18,7 +20,11 @@ export async function fetchMap(mapOptions, mapStyle) {
 
   const response = await fetch(`${serverUrl}/generateImage`, options);
   const blob = await response.blob();
-
+  if (response && response.status === 500) {
+    renderQueue.remove(this, {
+      error: new Error(`Received status code 500 from generator-server`),
+    });
+  }
   return new Promise(resolve => {
     const reader = new window.FileReader();
     reader.readAsDataURL(blob);


### PR DESCRIPTION
To test the error throwing you need to have generator-server running locally and have changes in ```server.js``` so that ```/generateImage``` returns status 500. E.g change line 109 to ```processResult = false;```.

It would probably also be wise to test in dev by generating big set of posters so there might actually be "real" cases when the generator-server fails to deliver map and the publisher backend throws errors.