### PR TITLE
Preserve poster order

### DIFF
--- a/migrations/20191216105850_poster_order.js
+++ b/migrations/20191216105850_poster_order.js
@@ -1,0 +1,7 @@
+exports.up = async function(knex) {
+  await knex.schema.alterTable('poster', table => {
+    table.integer('order');
+  });
+};
+
+exports.down = function() {};

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -173,10 +173,20 @@ async function main() {
 
   router.post('/posters', async ctx => {
     const { buildId, component, props, template } = ctx.request.body;
+    const build = await getBuild({ id: buildId });
     const posters = [];
 
     for (let i = 0; i < props.length; i++) {
-      posters.push(generatePoster(buildId, component, template, props[i], i));
+      const currentProps = props[i];
+      let orderNumber = get(
+        build.posters.find(
+          poster => poster.props.stopId === currentProps.stopId && poster.status === 'FAILED',
+        ),
+        'order',
+        null,
+      );
+      if (!orderNumber) orderNumber = i + build.posters.length;
+      posters.push(generatePoster(buildId, component, template, currentProps, orderNumber));
     }
 
     try {

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -1,3 +1,5 @@
+const orderBy = require('lodash/orderBy');
+const get = require('lodash/get');
 const Koa = require('koa');
 const Router = require('koa-router');
 const cors = require('@koa/cors');
@@ -30,12 +32,13 @@ const { downloadPostersFromCloud } = require('./cloudService');
 
 const PORT = 4000;
 
-async function generatePoster(buildId, component, template, props) {
+async function generatePoster(buildId, component, template, props, index) {
   const { id } = await addPoster({
     buildId,
     component,
     template,
     props,
+    order: index,
   });
 
   const onInfo = (message = 'No message.') => {
@@ -171,11 +174,16 @@ async function main() {
   router.post('/posters', async ctx => {
     const { buildId, component, props, template } = ctx.request.body;
     const posters = [];
+
     for (let i = 0; i < props.length; i++) {
-      // eslint-disable-next-line no-await-in-loop
-      posters.push(await generatePoster(buildId, component, template, props[i]));
+      posters.push(generatePoster(buildId, component, template, props[i], i));
     }
-    ctx.body = posters;
+
+    try {
+      ctx.body = await Promise.all(posters);
+    } catch (err) {
+      ctx.throw(500, err.message || 'Poster generation failed.');
+    }
   });
 
   router.delete('/posters/:id', async ctx => {
@@ -213,6 +221,7 @@ async function main() {
     const { id } = ctx.params;
     const { title, posters } = await getBuild({ id });
     let filename;
+
     const posterIds = posters.filter(poster => poster.status === 'READY').map(poster => poster.id);
     const downloadedPosterIds = await downloadPostersFromCloud(posterIds);
 
@@ -221,7 +230,17 @@ async function main() {
     }
 
     try {
-      filename = await generator.concatenate(downloadedPosterIds, title);
+      // Get the order of the downloaded posters and sort the posters before concatenation.
+      const orderedPosters = orderBy(
+        downloadedPosterIds.map(downloadedId => ({
+          id: downloadedId,
+          order: get(posters.find(({ id: posterId }) => posterId === downloadedId), 'order', 0),
+        })),
+        'order',
+        'asc',
+      );
+
+      filename = await generator.concatenate(orderedPosters.map(poster => poster.id), title);
       await generator.removeFiles(downloadedPosterIds);
     } catch (err) {
       ctx.throw(500, err.message || 'PDF concatenation failed.');

--- a/scripts/store.js
+++ b/scripts/store.js
@@ -68,6 +68,7 @@ async function getBuild({ id }) {
       'poster.props',
       'poster.created_at',
       'poster.updated_at',
+      'poster.order',
       knex.raw(`json_agg(
                 json_build_object(
                     'type', event.type,

--- a/scripts/store.js
+++ b/scripts/store.js
@@ -126,10 +126,10 @@ async function getPoster({ id }) {
   return convertKeys(row, camelCase);
 }
 
-async function addPoster({ buildId, component, props }) {
+async function addPoster({ buildId, component, props, order }) {
   const id = uuidv1();
-  await knex('poster').insert(
-    convertKeys(
+  await knex('poster').insert({
+    ...convertKeys(
       {
         id,
         buildId,
@@ -138,7 +138,8 @@ async function addPoster({ buildId, component, props }) {
       },
       snakeCase,
     ),
-  );
+    order,
+  });
   return { id };
 }
 


### PR DESCRIPTION
It is important to preserve the order of the posters in the concatenated file. This has become a problem since we started to use multiple instances of the server and storing the files in Azure, as they would be downloaded in a random order.

This PR adds an `order` column to the poster table which stores the order in which the posters where submitted from the UI. The UI has had ordering logic for a while. When downloading the generated posters and concatenating them, the posters are reordered according to the associated order number from the database.