### PR TITLE
MM-230: Configure github actions

### DIFF
--- a/.github/workflows/buildAndPublish_dev.yml
+++ b/.github/workflows/buildAndPublish_dev.yml
@@ -1,0 +1,34 @@
+name: Build and publish Docker Hub dev image
+
+on:
+  pull_request:
+    branches:
+      - 'master'
+
+jobs:
+  build-container:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.KARTAT_DOCKERHUB_USER }}
+          password: ${{ secrets.KARTAT_DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: hsldevcom/hsl-map-publisher
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          name: hsldevcom/hsl-map-publisher
+          tags: ${{ steps.meta.outputs.tags }} 'DEV'
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/buildAndPublish_prod.yml
+++ b/.github/workflows/buildAndPublish_prod.yml
@@ -1,0 +1,34 @@
+name: Build and publish Docker Hub prod image
+
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  build-container:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.KARTAT_DOCKERHUB_USER }}
+          password: ${{ secrets.KARTAT_DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: hsldevcom/hsl-map-publisher
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          name: hsldevcom/hsl-map-publisher
+          push: ${{ github.event_name == 'push' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Configure github actions to deploy to Docker Hub such that:

"Dev" tag is built and deployed when a pull request is made to production
"Production" tag is built and deployed when a merge (push) is made to production