### PR TITLE
MM-265: Timestamped docker images

### DIFF
--- a/.github/workflows/buildAndPublish_dev.yml
+++ b/.github/workflows/buildAndPublish_dev.yml
@@ -23,6 +23,21 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: hsldevcom/hsl-map-publisher
+      
+      - name: Get commit hash
+        id: commit_hash
+        run: echo "::set-output name=hash::$(git rev-parse --short "$GITHUB_SHA")"
+
+      - name: Get image timestamp
+        id: timestamp
+        run: echo "::set-output name=timestamp::$(date +'%Y-%m-%d')"
+
+      - name: Build and push timestamped tag
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ format('hsldevcom/hsl-map-publisher:dev-{0}-{1}', steps.timestamp.outputs.timestamp, steps.commit_hash.outputs.hash)
 
       - name: Build and push
         uses: docker/build-push-action@v2
@@ -30,4 +45,3 @@ jobs:
           context: .
           push: true
           tags: hsldevcom/hsl-map-publisher:dev
-          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/buildAndPublish_prod.yml
+++ b/.github/workflows/buildAndPublish_prod.yml
@@ -24,11 +24,24 @@ jobs:
         with:
           images: hsldevcom/hsl-map-publisher
 
+      - name: Get commit hash
+        id: commit_hash
+        run: echo "::set-output name=hash::$(git rev-parse --short "$GITHUB_SHA")"
+
+      - name: Get image timestamp
+        id: timestamp
+        run: echo "::set-output name=timestamp::$(date +'%Y-%m-%d')"
+
+      - name: Build and push timestamped tag
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: ${{ github.event_name == 'push' }}
+          tags: ${{ format('hsldevcom/hsl-map-publisher:prod-{0}-{1}', steps.timestamp.outputs.timestamp, steps.commit_hash.outputs.hash)
+
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: .
-          name: hsldevcom/hsl-map-publisher
           push: ${{ github.event_name == 'push' }}
           tags: hsldevcom/hsl-map-publisher:prod
-          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This version of the workflows creates the timestamp and short commit hash, adds them into a tag and pushes to docker hub along with the regular 'dev' or 'prod' image push.