### PR TITLE
MM-334 - Configure dependabot PR target branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# Specify a non-default branch for pull requests for npm
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    # Raise pull requests for version updates
+    # to npm against the `development` branch
+    target-branch: "development"
+    # Labels on pull requests for version updates only
+    labels:
+      - "NPM Dependencies"


### PR DESCRIPTION
Set target branch to development so we can actually properly test and validate dependabot PRs.