### PR TITLE
MM-502: Add more functionality to generateRenderUrl endpoint and rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,12 +143,12 @@ Server:
 docker run -d -p 4000:4000 --name publisher-server -v $(pwd)/output:/output -v $(pwd)/fonts:/fonts --link publisher-postgres --link redis -e SERVICE=server:production hsl-map-publisher
 ```
 
-Worker:
-```bash
-docker run -d --name publisher-worker -v $(pwd)/output:/output -v $(pwd)/fonts:/fonts --link publisher-postgres --link redis --link publisher-render -e SERVICE=worker:production hsl-map-publisher
-```
-
 Rendering:
 ```bash
 docker run -d -p 5000:5000 --name publisher-render -v $(pwd)/output:/output -v $(pwd)/fonts:/fonts --link publisher-postgres --link redis -e SERVICE=start:production hsl-map-publisher
+```
+
+And finally a Worker, which is linked to the rendering instance:
+```bash
+docker run -d --name publisher-worker -v $(pwd)/output:/output -v $(pwd)/fonts:/fonts --link publisher-postgres --link redis --link publisher-render -e SERVICE=worker:production hsl-map-publisher
 ```

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "koa-router": "^7.4.0",
     "koa-session": "^5.10.1",
     "lodash": "^4.17.21",
+    "moment": "^2.29.4",
     "node-fetch": "^1.7.3",
     "p-map": "^1.2.0",
     "pdf-merger-js": "^3.4.0",

--- a/scripts/generator.js
+++ b/scripts/generator.js
@@ -4,6 +4,7 @@ const puppeteer = require('puppeteer');
 const qs = require('qs');
 const log = require('./util/log');
 const { uploadPosterToCloud } = require('./cloudService');
+const moment = require('moment');
 
 const { AZURE_STORAGE_ACCOUNT, AZURE_STORAGE_KEY, PUBLISHER_RENDER_URL } = require('../constants');
 
@@ -29,7 +30,10 @@ async function initialize() {
 }
 
 function generateRenderUrl(component, template, props) {
-  const encodedProps = qs.stringify({ component, props, template });
+  const generationProps = props.date
+    ? props
+    : Object.assign(props, { date: moment(Date()).format('YYYY-MM-DD') }); // Add current date by default if request props do not contain it
+  const encodedProps = qs.stringify({ component, props: generationProps, template });
   const pageUrl = `${PUBLISHER_RENDER_URL}/?${encodedProps}`;
   return pageUrl;
 }

--- a/src/components/timetable/timetable.css
+++ b/src/components/timetable/timetable.css
@@ -140,3 +140,30 @@
   font-family: GothamRounded-Medium;
   text-transform: uppercase;
 }
+
+.printBtn {
+  margin-left: 2rem;
+  background-color: var(--hsl-blue);
+  margin-top: 1.5rem;
+  height: 2rem;
+  width: fit-content;
+  padding: 0 1rem 0 1rem;
+  font-size: 0.9rem;
+  border-radius: 10px;
+  color: white;
+  border: none;
+}
+
+.printBtn:hover {
+  background-color: white;
+  cursor: pointer;
+  color: var(--hsl-blue);
+  border: 1px solid var(--hsl-blue);
+}
+
+@media print {
+  .noPrint,
+  .noPrint * {
+    display: none !important;
+  }
+}

--- a/src/components/timetable/timetable.js
+++ b/src/components/timetable/timetable.js
@@ -68,7 +68,7 @@ class Timetable extends Component {
 
   componentDidMount() {
     const { renderAddressInfo } = this.state;
-    if (!renderAddressInfo && this.props.printableAsA4) {
+    if (!renderAddressInfo && this.props.printableAsA4 && this.props.showAddressInfo) {
       this.setState({ renderAddressInfo: true });
     }
   }
@@ -229,6 +229,7 @@ Timetable.defaultProps = {
   specialSymbols: [],
   platform: null,
   addressFi: null,
+  showAddressInfo: true,
 };
 
 Timetable.propTypes = {
@@ -257,6 +258,7 @@ Timetable.propTypes = {
   platformInfo: PropTypes.bool,
   specialSymbols: PropTypes.array,
   hasDepartures: PropTypes.bool.isRequired,
+  showAddressInfo: PropTypes.bool,
 };
 
 export default Timetable;

--- a/src/components/timetable/timetable.js
+++ b/src/components/timetable/timetable.js
@@ -58,6 +58,14 @@ const getNotes = (notes, symbols) => {
   return parsedNotes;
 };
 
+const PrintButton = props => (
+  <div className={styles.noPrint}>
+    <button className={styles.printBtn} type="button" onClick={window.print}>
+      TULOSTA AIKATAULU
+    </button>
+  </div>
+);
+
 class Timetable extends Component {
   constructor(props) {
     super(props);
@@ -126,6 +134,7 @@ class Timetable extends Component {
                   <PlatformSymbol platform={this.props.platform} />
                 )}
               </div>
+              {this.props.showPrintButton ? <PrintButton /> : ''}
             </div>
           )}
           {this.props.showValidityPeriod && (
@@ -230,6 +239,7 @@ Timetable.defaultProps = {
   platform: null,
   addressFi: null,
   showAddressInfo: true,
+  showPrintButton: false,
 };
 
 Timetable.propTypes = {
@@ -259,6 +269,7 @@ Timetable.propTypes = {
   specialSymbols: PropTypes.array,
   hasDepartures: PropTypes.bool.isRequired,
   showAddressInfo: PropTypes.bool,
+  showPrintButton: PropTypes.bool,
 };
 
 export default Timetable;

--- a/src/components/timetable/timetableContainer.js
+++ b/src/components/timetable/timetableContainer.js
@@ -268,6 +268,7 @@ const propsMapper = mapProps(props => {
     specialSymbols,
     platformInfo: props.platformInfo,
     hasDepartures: departures.length > 0,
+    showAddressInfo: props.showAddressInfo,
   };
 });
 
@@ -287,6 +288,7 @@ TimetableContainer.defaultProps = {
   printTimetablesAsGreyscale: false,
   specialSymbols: [],
   showStopInformation: false,
+  showAddressInfo: true,
 };
 
 TimetableContainer.propTypes = {
@@ -304,6 +306,7 @@ TimetableContainer.propTypes = {
   printTimetablesAsGreyscale: PropTypes.bool,
   specialSymbols: PropTypes.array,
   showStopInformation: PropTypes.bool,
+  showAddressInfo: PropTypes.bool,
 };
 
 export default TimetableContainer;

--- a/src/components/timetable/timetableContainer.js
+++ b/src/components/timetable/timetableContainer.js
@@ -269,6 +269,7 @@ const propsMapper = mapProps(props => {
     platformInfo: props.platformInfo,
     hasDepartures: departures.length > 0,
     showAddressInfo: props.showAddressInfo,
+    showPrintButton: props.showPrintButton,
   };
 });
 
@@ -289,6 +290,7 @@ TimetableContainer.defaultProps = {
   specialSymbols: [],
   showStopInformation: false,
   showAddressInfo: true,
+  showPrintButton: false,
 };
 
 TimetableContainer.propTypes = {
@@ -307,6 +309,7 @@ TimetableContainer.propTypes = {
   specialSymbols: PropTypes.array,
   showStopInformation: PropTypes.bool,
   showAddressInfo: PropTypes.bool,
+  showPrintButton: PropTypes.bool,
 };
 
 export default TimetableContainer;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7728,6 +7728,11 @@ mkdirp@^0.5.5:
   dependencies:
     minimist "^1.2.6"
 
+moment@^2.29.4:
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"


### PR DESCRIPTION
- Add current date by default unless date is included in generateRenderUrl params
- Added parameter to hide address info from the output (Visible by default)
- Added parameter to add a print button into the output (Hidden by default)

HOW TO TEST:
Spin up the local dev environment and include `showAddressInfo` and `showPrintButton` boolean parameters with the endpoint query
