### PR TITLE
Allow route title to enter the padding area

### DIFF
--- a/src/components/stopPoster/routes.css
+++ b/src/components/stopPoster/routes.css
@@ -110,7 +110,7 @@
 }
 
 .title {
-  padding-right: 0.893em;
+  /* padding-right: 0.893em; */ /* Removed to allow more space for overflow */
   font-family: GothamXNarrow-Medium;
   font-size: 0.83em;
 }

--- a/src/components/stopPoster/routes.js
+++ b/src/components/stopPoster/routes.js
@@ -49,7 +49,9 @@ class Routes extends Component {
   }
 
   hasOverflow() {
-    return this.root.scrollWidth > this.root.clientWidth;
+    // Allow extra 50px room for text to enter the padding to prevent failure with overflow removal
+    // Remove if that causes problems
+    return this.root.scrollWidth > this.root.clientWidth + 50;
   }
 
   updateLayout() {


### PR DESCRIPTION
This allow rendering to continue and not to fail if the route title is too long.