### PR TITLE
MM-522: Fix single departure grouping with same minutes

### DIFF
--- a/src/components/timetable/tableRows.js
+++ b/src/components/timetable/tableRows.js
@@ -4,6 +4,7 @@ import groupBy from 'lodash/groupBy';
 import { Row, WrappingRow } from 'components/util';
 import sortBy from 'lodash/sortBy';
 import { trimRouteId } from 'util/domain';
+import { uniqBy } from 'lodash';
 
 import styles from './tableRows.css';
 
@@ -87,6 +88,11 @@ const getDuplicateCutOff = (startIndex, rows) => {
   return cutOffIndex;
 };
 
+const filterDuplicateDepartureHours = departureRows => {
+  console.log(uniqBy(departureRows, 'departures'));
+  return uniqBy(departureRows, 'departures');
+};
+
 const TableRows = props => {
   const departuresByHour = groupBy(
     props.departures,
@@ -108,16 +114,13 @@ const TableRows = props => {
         : `${formatHour(rows[i].hour)}-${formatHour(rows[cutOff].hour)}`;
     if (rows.length === 2) {
       hours = `${formatHour(rows[i].hour)}`;
-
-      rowsByHour.push({
-        hour: hours,
-        departures: rows[i].departures,
-      });
-
-      rowsByHour.push({
+      const firstHour = { hour: hours, departures: rows[i].departures };
+      const secondHour = {
         hour: `${formatHour(rows[rows.length - 1].hour)}`,
         departures: rows[rows.length - 1].departures,
-      });
+      };
+
+      rowsByHour.push(firstHour, secondHour);
       i = cutOff;
     } else {
       rowsByHour.push({
@@ -128,9 +131,11 @@ const TableRows = props => {
     }
   }
 
+  const filteredDepartures = filterDuplicateDepartureHours(rowsByHour);
+
   return (
     <div className={styles.root}>
-      {rowsByHour.map(departuresHour => (
+      {filteredDepartures.map(departuresHour => (
         <TableRow
           key={`${departuresHour.hour}${departuresHour.departures}`}
           hours={departuresHour.hour}

--- a/src/components/timetable/tableRows.js
+++ b/src/components/timetable/tableRows.js
@@ -102,15 +102,30 @@ const TableRows = props => {
   const rowsByHour = [];
   for (let i = 0; i < rows.length; i++) {
     const cutOff = getDuplicateCutOff(i, rows);
-    const hours =
+    let hours =
       rows[i].hour === rows[cutOff].hour
         ? `${formatHour(rows[i].hour)}`
         : `${formatHour(rows[i].hour)}-${formatHour(rows[cutOff].hour)}`;
-    rowsByHour.push({
-      hour: hours,
-      departures: rows[i].departures,
-    });
-    i = cutOff;
+    if (rows.length === 2) {
+      hours = `${formatHour(rows[i].hour)}`;
+
+      rowsByHour.push({
+        hour: hours,
+        departures: rows[i].departures,
+      });
+
+      rowsByHour.push({
+        hour: `${formatHour(rows[rows.length - 1].hour)}`,
+        departures: rows[rows.length - 1].departures,
+      });
+      i = cutOff;
+    } else {
+      rowsByHour.push({
+        hour: hours,
+        departures: rows[i].departures,
+      });
+      i = cutOff;
+    }
   }
 
   return (


### PR DESCRIPTION
How to test:
- Clone
- Start local instance as usual

Open timetable generation url for stop ID that previously showed departures every hour on weekends:
http://localhost:5000/?component=Timetable&props%5BstopId%5D=6300204&props%5Bdate%5D=2023-08-17&props%5BisSummerTimetable%5D=true&props%5BdateBegin%5D=&props%5BdateEnd%5D=&props%5BprintTimetablesAsA4%5D=false&props%5BprintTimetablesAsGreyscale%5D=false