### PR TITLE
#26114: language change for print button

### DIFF
--- a/src/components/timetable/timetable.js
+++ b/src/components/timetable/timetable.js
@@ -58,13 +58,21 @@ const getNotes = (notes, symbols) => {
   return parsedNotes;
 };
 
-const PrintButton = props => (
-  <div className={styles.noPrint}>
-    <button className={styles.printBtn} type="button" onClick={window.print}>
-      TULOSTA AIKATAULU
-    </button>
-  </div>
-);
+const PrintButton = lang => {
+  const PRINT_TEXT = {
+    fi: 'TULOSTA AIKATAULU',
+    sv: 'UTSKRIVA TIDTABEL',
+    en: 'PRINT SCHEDULE',
+  };
+
+  return (
+    <div className={styles.noPrint}>
+      <button className={styles.printBtn} type="button" onClick={window.print}>
+        {PRINT_TEXT[lang.lang]}
+      </button>
+    </div>
+  );
+};
 
 class Timetable extends Component {
   constructor(props) {
@@ -134,7 +142,7 @@ class Timetable extends Component {
                   <PlatformSymbol platform={this.props.platform} />
                 )}
               </div>
-              {this.props.showPrintButton ? <PrintButton /> : ''}
+              {this.props.showPrintButton ? <PrintButton lang={this.props.lang} /> : ''}
             </div>
           )}
           {this.props.showValidityPeriod && (
@@ -233,6 +241,7 @@ Timetable.defaultProps = {
   addressFi: null,
   showAddressInfo: true,
   showPrintButton: false,
+  lang: 'fi',
 };
 
 Timetable.propTypes = {
@@ -264,6 +273,7 @@ Timetable.propTypes = {
   showAddressInfo: PropTypes.bool,
   showPrintButton: PropTypes.bool,
   combinedDays: PropTypes.object.isRequired,
+  lang: PropTypes.string,
 };
 
 export default Timetable;

--- a/src/components/timetable/timetable.js
+++ b/src/components/timetable/timetable.js
@@ -61,7 +61,7 @@ const getNotes = (notes, symbols) => {
 const PrintButton = lang => {
   const PRINT_TEXT = {
     fi: 'TULOSTA AIKATAULU',
-    sv: 'UTSKRIVA TIDTABEL',
+    sv: 'SKRIV UT TIDTABEL',
     en: 'PRINT SCHEDULE',
   };
 

--- a/src/components/timetable/timetableContainer.js
+++ b/src/components/timetable/timetableContainer.js
@@ -408,6 +408,7 @@ const propsMapper = mapProps(props => {
     hasDepartures: departures.length > 0,
     showAddressInfo: props.showAddressInfo,
     showPrintButton: props.showPrintButton,
+    lang: props.lang,
   };
 });
 
@@ -429,6 +430,7 @@ TimetableContainer.defaultProps = {
   showStopInformation: false,
   showAddressInfo: true,
   showPrintButton: false,
+  lang: 'fi',
 };
 
 TimetableContainer.propTypes = {
@@ -449,6 +451,7 @@ TimetableContainer.propTypes = {
   showAddressInfo: PropTypes.bool,
   showPrintButton: PropTypes.bool,
   combinedDays: PropTypes.object,
+  lang: PropTypes.string,
 };
 
 export default TimetableContainer;


### PR DESCRIPTION
Timetable rendering API now accepts `lang` parameter with `fi`, `sv` and `en` as options for changing the print button language.