### PR TITLE
Make the usage of Docker Compose easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Remember to also include `DIGITRANSIT_APIKEY` !
 Build the local version of `hsl-map-publisher`:
 
 ``` 
-docker build --build-arg BUILD_ENV=local -t hsl-map-publisher .
+docker compose build
 ```
 
 Setup the development environment:

--- a/compose.yaml
+++ b/compose.yaml
@@ -16,12 +16,18 @@ services:
 
   publisher-server:
     image: hsl-map-publisher
+    build:
+      context: .
+      args:
+        - BUILD_ENV=local
+      platforms:
+        - "linux/amd64"
     ports:
       - 4000:4000
     environment:
       - SERVICE=server:production
     volumes:
-      - ./output:/output
+      - ./output:/opt/publisher/output
       - ./fonts:/fonts
     depends_on:
       publisher-postgres:
@@ -31,12 +37,12 @@ services:
   
   publisher-render:
     image: hsl-map-publisher
+    pull_policy: never # use the same build as publisher-server
     ports:
       - 5000:5000
     environment:
       - SERVICE=start:production
     volumes:
-      - ./output:/output
       - ./fonts:/fonts
     depends_on:
       publisher-postgres:
@@ -46,12 +52,13 @@ services:
   
   publisher-worker:
     image: hsl-map-publisher
+    pull_policy: never # use the same build as publisher-server
     deploy:
       replicas: 2
     environment:
       - SERVICE=worker:production
     volumes:
-      - ./output:/output
+      - ./output:/opt/publisher/output
       - ./fonts:/fonts
     depends_on:
       publisher-postgres:


### PR DESCRIPTION
Add specs for building a local docker image using compose file, so there's no need for a separate build.