### PR TITLE
AB#33966: Expose local env file in compose

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -20,6 +20,7 @@ services:
       context: .
       args:
         - BUILD_ENV=local
+        - DIGITRANSIT_APIKEY=${DIGITRANSIT_APIKEY}
       platforms:
         - "linux/amd64"
     ports:
@@ -34,6 +35,8 @@ services:
         condition: service_started
       redis:
         condition: service_started
+    env_file:
+      - .env.local
   
   publisher-render:
     image: hsl-map-publisher


### PR DESCRIPTION
Exposed the `.env.local` file for Docker compose to allow access to `DIGITRANSIT_APIKEY` locally without extra commands during build.