### PR TITLE
AB#54863: Fix broken URL in string template resulting in unbound query

### DIFF
--- a/src/components/map/stopMapContainer.js
+++ b/src/components/map/stopMapContainer.js
@@ -320,9 +320,7 @@ const fetchOSMObjects = async props => {
   let results;
   try {
     const osmData = await fetch(
-      `https://nominatim.openstreetmap.org/search.php?q=subway_entrance&
-      viewbox=${props.maxInterestLon}%2C${props.maxInterestLat}%2C${props.minInterestLon}%2C${props.minInterestLat}
-      &bounded=1&format=json&namedetails=1`,
+      `https://nominatim.openstreetmap.org/search.php?q=subway_entrance&viewbox=${props.maxInterestLon}%2C${props.maxInterestLat}%2C${props.minInterestLon}%2C${props.minInterestLat}&bounded=1&format=json&namedetails=1`,
     );
     results = await osmData.json();
   } catch (e) {


### PR DESCRIPTION
The line breaks inside the string template caused the `bounded` parameter to be dropped from the URL, resulting in weird behavior.