### PR TITLE
AB#57920: Add line query input option for StopRoutePlate

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -12,7 +12,7 @@ import A3StopPoster from 'components/a3stopPoster/a3StopPosterContainer';
 import TerminalPoster from 'components/stopPoster/terminalPosterContainer';
 import LineTimetable from 'components/lineTimetable/lineTimetableContainer';
 import CoverPage from 'components/coverPage/coverPageContainer';
-import StopRoutePlate from './stopRoutePlate/stopRoutePlateContainer';
+import * as StopRoutePlate from './stopRoutePlate/stopRoutePlateContainer';
 import renderQueue from 'util/renderQueue';
 
 const components = {
@@ -111,6 +111,14 @@ class App extends Component {
 
     if (ComponentToRender === components.LineTimetable) {
       rootStyle = { display: 'block' };
+    }
+
+    if (ComponentToRender === components.StopRoutePlate) {
+      if (props.useLineQuery) {
+        ComponentToRender = StopRoutePlate.LineQueryStopRoutePlateContainer;
+      } else {
+        ComponentToRender = StopRoutePlate.StopRoutePlateContainer;
+      }
     }
 
     return (

--- a/src/components/stopRoutePlate/stopRoutePlate.js
+++ b/src/components/stopRoutePlate/stopRoutePlate.js
@@ -60,6 +60,24 @@ const StopRoutePlate = props => {
     { label: 'Lopputulos', key: 'routeChanges.formatted.endResult' },
   ];
 
+  const lineQueryCsvHeaders = [
+    { label: 'Sisältö', key: 'summary' },
+    { label: 'Linja', key: 'stop.queriedRouteIdParsed' },
+    { label: 'Nimi FI', key: 'stop.nameFi' },
+    { label: 'Nimi SE', key: 'stop.nameSe' },
+    { label: 'Pysäkkityyppi', key: 'stop.stopType' },
+    { label: 'Vyöhyke', key: 'stop.stopZone' },
+    { label: 'Tunnus', key: 'stop.shortId' },
+    { label: 'Laiturinumero', key: 'stop.platform' },
+    { label: 'Sijainti', key: 'stop.linkToLocation' },
+    { label: 'Koordinaatit', key: 'stop.latLon' },
+    { label: 'Muutospäivämäärä (aikaisin)', key: 'routeChanges.formatted.earliestChangeDate' },
+    { label: 'Muuttumattomat', key: 'routeChanges.formatted.unchanged' },
+    { label: 'Uudet', key: 'routeChanges.formatted.added' },
+    { label: 'Poistettavat', key: 'routeChanges.formatted.removed' },
+    { label: 'Lopputulos', key: 'routeChanges.formatted.endResult' },
+  ];
+
   const summaryCsvHeaders = [
     { label: 'Vertailuväli', key: 'comparisonDateRange' },
     { label: 'Kilpi', key: 'plateText' },
@@ -98,7 +116,7 @@ const StopRoutePlate = props => {
         <CSVDownload
           filename={props.csvFileName ? props.csvFileName : 'unnamed'}
           data={[generationSummary, ...routeDiffs]}
-          headers={csvHeaders}
+          headers={props.usesLineQuery ? lineQueryCsvHeaders : csvHeaders}
         />
       )}
       {downloadSummary && (
@@ -115,6 +133,7 @@ const StopRoutePlate = props => {
 StopRoutePlate.defaultProps = {
   downloadTable: false,
   downloadSummary: false,
+  usesLineQuery: false,
 };
 
 StopRoutePlate.propTypes = {
@@ -125,6 +144,7 @@ StopRoutePlate.propTypes = {
   csvFileName: PropTypes.string.isRequired,
   dateBegin: PropTypes.string.isRequired,
   dateEnd: PropTypes.string.isRequired,
+  usesLineQuery: PropTypes.bool,
 };
 
 export default StopRoutePlate;


### PR DESCRIPTION
This PR adds another Higher Order Component (HOC) onto the same `StopRoutePlate` component that gets rendered upon providing the `useLineQuery` boolean query param. Omitting the parameter or providing `useLineQuery=false` will instead render the basic `StopRoutePlate` component.