### PR TITLE
AB#64927: Refactor LineTimetable Line handling

### DIFF
--- a/scripts/server.js
+++ b/scripts/server.js
@@ -42,7 +42,6 @@ const {
 
 const { downloadPostersFromCloud } = require('./cloudService');
 const { forEach } = require('lodash');
-const { truncateLineId } = require('../src/util/domain');
 
 const PORT = 4000;
 
@@ -533,6 +532,10 @@ async function main() {
     };
   };
 
+  const truncateLineId = lineId => {
+    return lineId.substring(0, 4);
+  };
+
   unAuthorizedRouter.post('/generateRenderUrl', koaBody(), async ctx => {
     let { props } = ctx.request.body;
     const { component } = ctx.request.body;
@@ -546,12 +549,13 @@ async function main() {
 
     if (component === RENDER_URL_COMPONENTS.LINE_TIMETABLE) {
       const truncatedLineId = truncateLineId(props.lineId);
+      props.lineId = truncatedLineId; // Query "base" lineId only, letter variants are merged in the result.
+
       if (!props.dateBegin && !props.dateEnd) {
         // Add default date range if not provided, which is a week from today
         props = {
           ...props,
           ...getCurrentWeekDates(),
-          lineId: truncatedLineId,
         };
       }
     }

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -42,6 +42,7 @@ const {
 
 const { downloadPostersFromCloud } = require('./cloudService');
 const { forEach } = require('lodash');
+const { truncateLineId } = require('../src/util/domain');
 
 const PORT = 4000;
 
@@ -544,11 +545,13 @@ async function main() {
     }
 
     if (component === RENDER_URL_COMPONENTS.LINE_TIMETABLE) {
+      const truncatedLineId = truncateLineId(props.lineId);
       if (!props.dateBegin && !props.dateEnd) {
         // Add default date range if not provided, which is a week from today
         props = {
           ...props,
           ...getCurrentWeekDates(),
+          lineId: truncatedLineId,
         };
       }
     }
@@ -566,9 +569,9 @@ async function main() {
     const { lineId } = ctx.params;
     const { redirect, showPrintButton, lang } = ctx.request.query;
 
-    const modifiedLineId = lineId.substring(0, 4); // Skip letter variants
+    const truncatedLineId = truncateLineId(lineId); // Skip letter variants
     const renderUrl = generateRenderUrl('LineTimetable', 'default', {
-      lineId: modifiedLineId,
+      lineId: truncatedLineId,
       ...getCurrentWeekDates(),
       showPrintButton,
       lang,

--- a/src/util/domain.js
+++ b/src/util/domain.js
@@ -356,6 +356,10 @@ function getShelterText(stopType) {
   }
 }
 
+function truncateLineId(lineId) {
+  return lineId.substring(0, 4);
+}
+
 export {
   isNumberVariant,
   isRailRoute,
@@ -374,4 +378,5 @@ export {
   getFormattedRouteList,
   formatRouteString,
   getShelterText,
+  truncateLineId,
 };

--- a/src/util/domain.js
+++ b/src/util/domain.js
@@ -356,10 +356,6 @@ function getShelterText(stopType) {
   }
 }
 
-function truncateLineId(lineId) {
-  return lineId.substring(0, 4);
-}
-
 export {
   isNumberVariant,
   isRailRoute,
@@ -378,5 +374,4 @@ export {
   getFormattedRouteList,
   formatRouteString,
   getShelterText,
-  truncateLineId,
 };


### PR DESCRIPTION
This PR refactors the line query logic for LineTimetables, so that it returns the Lines more broadly, practically merging line letter variants under the "main" line in the rendered timetables. 
This addresses the issues that were faced regarding some of the letter variants being under their main line and some of them being their own lines. 